### PR TITLE
Defined missing includes. 

### DIFF
--- a/Software/Arduino code/OpenAstroTracker/InterruptCallback.hpp
+++ b/Software/Arduino code/OpenAstroTracker/InterruptCallback.hpp
@@ -1,4 +1,5 @@
 #pragma once
+
 #include "Globals.hpp"
 
 //////////////////////////////////////

--- a/Software/Arduino code/OpenAstroTracker/b_setup.hpp
+++ b/Software/Arduino code/OpenAstroTracker/b_setup.hpp
@@ -2,6 +2,11 @@
 
 #pragma once
 
+#include "OpenAstroTracker.hpp"
+#include "a_inits.hpp"
+#include "LcdMenu.hpp"
+#include "Utility.hpp"
+
 LcdMenu lcdMenu(16, 2, MAXMENUITEMS);
 LcdButtons lcdButtons(0);
 

--- a/Software/Arduino code/OpenAstroTracker/c725_menuHOME.hpp
+++ b/Software/Arduino code/OpenAstroTracker/c725_menuHOME.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "b_setup.hpp"
+
 #if HEADLESS_CLIENT == 0
 byte subGoIndex = 0;
 

--- a/Software/Arduino code/OpenAstroTracker/c_buttons.hpp
+++ b/Software/Arduino code/OpenAstroTracker/c_buttons.hpp
@@ -1,5 +1,16 @@
 #pragma once
 
+#include <Arduino.h>
+#include "b_setup.hpp"
+#include "c65_startup.hpp"
+#include "c70_menuRA.hpp"
+#include "c71_menuDEC.hpp"
+#include "c722_menuPOI.hpp"
+#include "c72_menuHA.hpp"
+#include "c75_menuCTRL.hpp"
+#include "c76_menuCAL.hpp"
+#include "c78_menuINFO.hpp"
+
 #if SUPPORT_SERIAL_CONTROL == 1
 #include "f_serial.hpp"
 #endif

--- a/Software/Arduino code/OpenAstroTracker/f_serial.hpp
+++ b/Software/Arduino code/OpenAstroTracker/f_serial.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "b_setup.hpp"
+
 #if SUPPORT_SERIAL_CONTROL == 1
 #include "MeadeCommandProcessor.hpp"
 


### PR DESCRIPTION
Before the references were just satisfied implicit by the include order in OpenAstroTracker.ino.

Without this fix IntelliSence cant resolve correct types and definitions in the IDE. 