### PR TITLE
Fixed mega2560 LCD issue by specifying LiquidCrystal lib by id. 

### DIFF
--- a/Software/Arduino code/OpenAstroTracker/platformio.ini
+++ b/Software/Arduino code/OpenAstroTracker/platformio.ini
@@ -15,7 +15,7 @@ src_dir = .
 lib_deps =
     SPI
     Serial
-    LiquidCrystal
+    887 # CrystalDisplay
     AccelStepper
     EEPROM
     Wire
@@ -29,7 +29,7 @@ lib_deps = ${common.lib_deps}
 
 [env:mega2560]
 platform = atmelavr
-board = megaatmega2560
+board = atmega2560
 
 [env:uno]
 platform = atmelavr


### PR DESCRIPTION
There are two libs with this name and PIO took the wrong one by specifying only the name.