### PR TITLE
Fix platformio builds

### DIFF
--- a/Software/Arduino code/OpenAstroTracker/platformio.ini
+++ b/Software/Arduino code/OpenAstroTracker/platformio.ini
@@ -10,19 +10,19 @@
 
 [platformio]
 src_dir = .
-default_envs = mega2560
+default_envs = mega2560, esp32
 
 [common]
 lib_deps = 
 	SPI
 	Serial
-	887
-	AccelStepper
+	887 # LiquidCrystal
+	265 # AccelStepper
 	EEPROM
 	Wire
 	TMCStepper
 	SoftwareSerial
-	TinyGPSPlus
+	1655 # TinyGPSPlus
 
 [env]
 framework = arduino


### PR DESCRIPTION
Some libraries unfortunatelly dont have a unique name (TinyGPSPlus, AccelStepper & LiquidCrystal). We can specify them by using library id.