### PR TITLE
Update platformio.yml

### DIFF
--- a/.github/workflows/platformio.yml
+++ b/.github/workflows/platformio.yml
@@ -2,6 +2,8 @@ name: PlatformIO CI
 
 on:  
   push:
+    branches:
+      - develop
   pull_request:
     branches:
       - develop


### PR DESCRIPTION
At the moment CI is triggered twice if someone pushes commits to a branch under PR to develop. Actually it runs on every push to any branch. This change limits it to pushes to develop and PRs agains develop only.