### PR TITLE
Bugfix/wrong version usage

### DIFF
--- a/Software/Arduino code/OpenAstroTracker/Version.h
+++ b/Software/Arduino code/OpenAstroTracker/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "V1.8.33"
+#define VERSION "V1.8.34"

--- a/Software/Arduino code/OpenAstroTracker/src/b_setup.hpp
+++ b/Software/Arduino code/OpenAstroTracker/src/b_setup.hpp
@@ -136,7 +136,7 @@ void setup() {
   Serial.begin(57600);
   //BT.begin(9600);
 
-  LOGV2(DEBUG_ANY, F("Hello, universe, this is OAT %s!"), version.c_str());
+  LOGV2(DEBUG_ANY, F("Hello, universe, this is OAT %s!"), VERSION);
 
   EPROMStore::initialize();
 


### PR DESCRIPTION
We were still using the old (not existing anymore) `version` variable instead of `VERSION` definition. This caused serial misbehavior.