### PR TITLE
Small code cleanup to improve readability

### DIFF
--- a/Software/Arduino code/OpenAstroTracker/Configuration.hpp
+++ b/Software/Arduino code/OpenAstroTracker/Configuration.hpp
@@ -28,19 +28,11 @@
   **/
 
 #if defined(ESP32) && __has_include("Configuration_local_esp32.hpp")                // ESP32
-    #define LOCAL_CONFIG "Configuration_local_esp32.hpp"
+    #include "Configuration_local_esp32.hpp"
 #elif defined(__AVR_ATmega2560__) && __has_include("Configuration_local_mega.hpp")  // Mega2560
-    #define LOCAL_CONFIG "Configuration_local_mega.hpp"
-#else                                                                               // Custom config
-    #define LOCAL_CONFIG "Configuration_local.hpp"
-#endif
-
-// Uncomment these two lines to override the automatic local config with yours.
-// #undef LOCAL_CONFIG 
-// #define LOCAL_CONFIG "Configuration_local_foo.hpp"
-
-#if __has_include(LOCAL_CONFIG)
-#include LOCAL_CONFIG
+    #include "Configuration_local_mega.hpp"
+#elif __has_include("Configuration_local.hpp")                                      // Custom config
+    #include "Configuration_local.hpp"
 #endif
 
 // Set to 1 for the northern hemisphere, 0 otherwise

--- a/Software/Arduino code/OpenAstroTracker/Configuration.hpp
+++ b/Software/Arduino code/OpenAstroTracker/Configuration.hpp
@@ -27,19 +27,11 @@
  * These files won't be tracked by Git and thus will remain after branch changes or code updates. 
   **/
 
-#if defined(ESP32)                  // ESP32
+#if defined(ESP32) && __has_include("Configuration_local_esp32.hpp")                // ESP32
     #define LOCAL_CONFIG "Configuration_local_esp32.hpp"
-    #if !__has_include(LOCAL_CONFIG)
-        #undef LOCAL_CONFIG 
-        #define LOCAL_CONFIG "Configuration_local.hpp"
-    #endif
-#elif defined(__AVR_ATmega2560__)   // Arduino Mega
+#elif defined(__AVR_ATmega2560__) && __has_include("Configuration_local_mega.hpp")  // Mega2560
     #define LOCAL_CONFIG "Configuration_local_mega.hpp"
-    #if !__has_include(LOCAL_CONFIG)
-        #undef LOCAL_CONFIG 
-        #define LOCAL_CONFIG "Configuration_local.hpp"
-    #endif
-#else                               // Other board?
+#else                                                                               // Custom config
     #define LOCAL_CONFIG "Configuration_local.hpp"
 #endif
 


### PR DESCRIPTION
- Removed redundant defines for the "default" local config
- Removed the "uncomment here" part because if the user will have to edit code, he could instead just rename a local config file. But this way he wont introduce changes to files indexed by git (thus avoid merge conflicts or unexpected issues).