### PR TITLE
V1.8.39 - Updates

### DIFF
--- a/Software/Arduino code/OpenAstroTracker/Configuration_adv.hpp
+++ b/Software/Arduino code/OpenAstroTracker/Configuration_adv.hpp
@@ -249,22 +249,25 @@
 ////////////////////////////
 // Debugging output control
 // Each bit in the debug level specifies a kind of debug to enable. Do not change.
-#define DEBUG_NONE           0x00
-#define DEBUG_INFO           0x01
-#define DEBUG_SERIAL         0x02
-#define DEBUG_WIFI           0x04
-#define DEBUG_MOUNT          0x08
-#define DEBUG_MOUNT_VERBOSE  0x10
-#define DEBUG_GENERAL        0x20
-#define DEBUG_MEADE          0x40
-#define DEBUG_VERBOSE        0x80
-#define DEBUG_ANY            0xFF
+#define DEBUG_NONE           0x0000
+#define DEBUG_INFO           0x0001
+#define DEBUG_SERIAL         0x0002
+#define DEBUG_WIFI           0x0004
+#define DEBUG_MOUNT          0x0008
+#define DEBUG_MOUNT_VERBOSE  0x0010
+#define DEBUG_GENERAL        0x0020
+#define DEBUG_MEADE          0x0040
+#define DEBUG_VERBOSE        0x0080
+#define DEBUG_STEPPERS       0x0100
+#define DEBUG_ANY            0xFFFF
 
 ////////////////////////////
 //
 // DEBUG OUTPUT
 //
 #define DEBUG_LEVEL (DEBUG_NONE)
+// #define DEBUG_LEVEL (DEBUG_STEPPERS|DEBUG_MOUNT)
+// #define DEBUG_LEVEL (DEBUG_INFO|DEBUG_MOUNT|DEBUG_GENERAL)
 // #define DEBUG_LEVEL (DEBUG_SERIAL|DEBUG_WIFI|DEBUG_INFO|DEBUG_MOUNT|DEBUG_GENERAL)
 // #define DEBUG_LEVEL (DEBUG_ANY)
 // #define DEBUG_LEVEL (DEBUG_INFO|DEBUG_MOUNT|DEBUG_GENERAL)

--- a/Software/Arduino code/OpenAstroTracker/Version.h
+++ b/Software/Arduino code/OpenAstroTracker/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "V1.8.38"
+#define VERSION "V1.8.39"

--- a/Software/Arduino code/OpenAstroTracker/src/Mount.hpp
+++ b/Software/Arduino code/OpenAstroTracker/src/Mount.hpp
@@ -353,6 +353,8 @@ private:
   float _trackingSpeed;
   float _trackingSpeedCalibration;
   unsigned long _lastDisplayUpdate;
+  unsigned long _trackerStoppedAt;
+  bool _compensateForTrackerOff;
   volatile int _mountStatus;
   char scratchBuffer[24];
   bool _stepperWasRunning;

--- a/Software/Arduino code/OpenAstroTracker/src/Utility.cpp
+++ b/Software/Arduino code/OpenAstroTracker/src/Utility.cpp
@@ -284,13 +284,17 @@ void logv(int levelFlags, String input, ...)
 {
   if ((levelFlags & DEBUG_LEVEL) != 0)
   {
+    unsigned long now = millis();
     va_list argp;
     va_start(argp, input);
     #if BUFFER_LOGS
       addToLogBuffer(formatArg(input.c_str(), argp));
     #else
+      Serial.print("[");    
+      Serial.print(String(now));
+      Serial.print("]:");    
       Serial.print(String(freeMemory()));
-      Serial.print(":");    
+      Serial.print(": ");    
       Serial.println(formatArg(input.c_str(), argp));
       Serial.flush();
     #endif

--- a/Software/Arduino code/OpenAstroTracker/src/b_setup.hpp
+++ b/Software/Arduino code/OpenAstroTracker/src/b_setup.hpp
@@ -227,7 +227,7 @@ void finishSetup()
     mount.configureDECStepper(HALFSTEP_MODE, DECmotorPin1, DECmotorPin2, DECmotorPin3, DECmotorPin4, RA_STEPPER_SPEED, DEC_STEPPER_ACCELERATION);
   #elif DEC_STEPPER_TYPE == STEPPER_TYPE_NEMA17
     LOGV1(DEBUG_ANY, F("Configure DEC stepper NEMA..."));
-    mount.configureDECStepper(DRIVER_MODE, DECmotorPin1, DECmotorPin2, RA_STEPPER_SPEED, DEC_STEPPER_ACCELERATION);
+    mount.configureDECStepper(DRIVER_MODE, DECmotorPin1, DECmotorPin2, DEC_STEPPER_SPEED, DEC_STEPPER_ACCELERATION);
   #else
     #error New stepper type? Configure it here.
   #endif

--- a/Software/Arduino code/OpenAstroTracker/src/c722_menuPOI.hpp
+++ b/Software/Arduino code/OpenAstroTracker/src/c722_menuPOI.hpp
@@ -2,8 +2,9 @@
 
 #if HEADLESS_CLIENT == 0
 #if SUPPORT_POINTS_OF_INTEREST == 1
-struct PointOfInterest {
-  const char* pDisplay;
+struct PointOfInterest
+{
+  const char *pDisplay;
   byte hourRA;
   byte minRA;
   byte secRA;
@@ -14,33 +15,35 @@ struct PointOfInterest {
 
 // Points of interest are sorted by DEC
 PointOfInterest pointOfInterest[] = {
-  //    Name (15chars)    RA (hms)     DEC (dms)
-  //  012345678901234
-  { ">Polaris"           ,  POLARIS_RA_HOUR, POLARIS_RA_MINUTE, POLARIS_RA_SECOND,  89, 21,  6 },
-  { ">Veil Nebula"     ,20, 51, 28,   30, 59, 30 },
-	{ ">M81 Bodes Galxy" , 9, 57, 13,   68, 58,  1 },
-	{ ">Cederblad 214"   , 0,  5, 46,   67, 16, 45 },
-	{ ">Heart Nebula"    , 2, 34, 57,   61, 31, 17 },
-	{ ">Navi"            , 0, 57, 57,   60, 49, 33 },
-	{ ">Soul Nebula"     , 2, 52, 47,   60, 30, 56 },
-	{ ">Elephant Trunk"  ,21, 39, 44,   57, 35, 31 },
-	{ ">Big Dipper"      ,12, 16, 26,   56, 55,  7 },
-	{ ">M101 Pinwheel"   ,14,  3, 56,   54, 15,  0 },
-	{ ">M51 Whirlpool"   ,13, 30, 45,   47,  5, 21 },
-	{ ">Deneb (Cygnus)"  ,20, 42,  7,   45, 21, 12 },
-	{ ">M63 Sunflower"   ,13, 16, 45,   41, 55, 14 },
-	{ ">M31 Andromeda"   , 0, 43, 52,   41, 22, 53 },
-	{ ">Vega"            ,18, 37, 37,   38, 48,  7 },
-	{ ">Arcturus"        ,14, 16, 37,   19,  5, 21 },
-	{ ">Altair"          ,19, 51, 45,    8, 55, 15 },
-	{ ">M42 Orion Nbula" , 5, 36, 18,   -5, 22, 44 },
-	{ ">Lagoon Nebula"   ,18,  5,  2,  -24, 22, 52 },
+    // Name (15chars)    RA (hms)     DEC (dms)
+    //0123456789012345
+    {">Polaris", POLARIS_RA_HOUR, POLARIS_RA_MINUTE, POLARIS_RA_SECOND, 89, 21, 6},
+    {">Veil Nebula", 20, 51, 28,     30, 59, 30},
+    {">M81 Bodes Galxy", 9, 57, 13,  68, 58, 1},
+    {">Cederblad 214", 0, 5, 46,     67, 16, 45},
+    {">Heart Nebula", 2, 34, 57,     61, 31, 17},
+    {">Navi", 0, 57, 57,             60, 49, 33},
+    {">Soul Nebula", 2, 52, 47,      60, 30, 56},
+    {">Elephant Trunk", 21, 39, 44,  57, 35, 31},
+    {">Big Dipper", 12, 16, 26,      56, 55, 7},
+    {">M101 Pinwheel", 14, 3, 56,    54, 15, 0},
+    {">M51 Whirlpool", 13, 30, 45,   47, 5, 21},
+    {">Deneb (Cygnus)", 20, 42, 7,   45, 21, 12},
+    {">M63 Sunflower", 13, 16, 45,   41, 55, 14},
+    {">M31 Andromeda", 0, 43, 52,    41, 22, 53},
+    {">Vega", 18, 37, 37,            38, 48, 7},
+    {">M33 Triangulum", 1, 35, 02,   30, 46, 5},
+    {">Pleiades 7Sistr", 3, 48, 15,  24, 10, 54},
+    {">Arcturus", 14, 16, 37,        19, 5, 21},
+    {">Altair", 19, 51, 45,           8, 55, 15},
+    {">M42 Orion Nbula", 5, 36, 18,  -5, 22, 44},
+    {">Lagoon Nebula", 18, 5, 2,    -24, 22, 52},
 
-  // Add new items above here, not below.
-  { ">Home"           ,  0,  0,  0,   90,  0,  0 },
-  { ">Unpark"         ,  0,  0,  0,   90,  0,  0 },
-  { ">Park"           ,  0,  0,  0,   90,  0,  0 },
-  // And definitely don't add here.
+    // Add new items above here, not below.
+    {">Home", 0, 0, 0, 90, 0, 0},
+    {">Unpark", 0, 0, 0, 90, 0, 0},
+    {">Park", 0, 0, 0, 90, 0, 0},
+    // And definitely don't add here.
 };
 
 int currentPOI = 0;
@@ -48,55 +51,68 @@ int parkPOI = sizeof(pointOfInterest) / sizeof(pointOfInterest[0]) - 1;
 int unparkPOI = sizeof(pointOfInterest) / sizeof(pointOfInterest[0]) - 2;
 byte homePOI = sizeof(pointOfInterest) / sizeof(pointOfInterest[0]) - 3;
 
-bool processPOIKeys() {
+bool processPOIKeys()
+{
   byte key;
   bool waitForRelease = false;
-  if (lcdButtons.keyChanged(&key)) {
+  if (lcdButtons.keyChanged(&key))
+  {
     waitForRelease = true;
-    switch (key) {
-      case btnSELECT: {
-        mount.stopSlewing(ALL_DIRECTIONS);
-        if (currentPOI == homePOI) {
-          mount.goHome();
-        }
-        else if (currentPOI == parkPOI) {
-          mount.park();
-        }
-        else if (currentPOI == unparkPOI) {
-          mount.startSlewing(TRACKING);
-        }
-        else {
-          PointOfInterest* poi = &pointOfInterest[currentPOI];
-          mount.targetRA().set(poi->hourRA, poi->minRA, poi->secRA);
-          mount.targetDEC().set(poi->degreeDEC - (NORTHERN_HEMISPHERE ? 90 : -90), poi->minDEC, poi->secDEC); // internal DEC degree is 0 at celestial poles
-          mount.startSlewingToTarget();
-        }
+    switch (key)
+    {
+    case btnSELECT:
+    {
+      mount.stopSlewing(ALL_DIRECTIONS);
+      if (currentPOI == homePOI)
+      {
+        mount.goHome();
       }
-      break;
+      else if (currentPOI == parkPOI)
+      {
+        mount.park();
+      }
+      else if (currentPOI == unparkPOI)
+      {
+        mount.startSlewing(TRACKING);
+      }
+      else
+      {
+        PointOfInterest *poi = &pointOfInterest[currentPOI];
+        mount.targetRA().set(poi->hourRA, poi->minRA, poi->secRA);
+        mount.targetDEC().set(poi->degreeDEC - (NORTHERN_HEMISPHERE ? 90 : -90), poi->minDEC, poi->secDEC); // internal DEC degree is 0 at celestial poles
+        mount.startSlewingToTarget();
+      }
+    }
+    break;
 
-      case btnLEFT:
-      case btnDOWN: {
-        currentPOI = adjustWrap(currentPOI, 1, 0, parkPOI);
-      }
-      break;
+    case btnLEFT:
+    case btnDOWN:
+    {
+      currentPOI = adjustWrap(currentPOI, 1, 0, parkPOI);
+    }
+    break;
 
-      case btnUP: {
-        currentPOI = adjustWrap(currentPOI, -1, 0, parkPOI);
-      }
-      break;
+    case btnUP:
+    {
+      currentPOI = adjustWrap(currentPOI, -1, 0, parkPOI);
+    }
+    break;
 
-      case btnRIGHT: {
-        lcdMenu.setNextActive();
-      }
-      break;
+    case btnRIGHT:
+    {
+      lcdMenu.setNextActive();
+    }
+    break;
     }
   }
 
   return waitForRelease;
 }
 
-void printPOISubmenu() {
-  if (mount.isSlewingIdle()) {
+void printPOISubmenu()
+{
+  if (mount.isSlewingIdle())
+  {
     lcdMenu.printMenu(pointOfInterest[currentPOI].pDisplay);
   }
 }


### PR DESCRIPTION
- Fixed guiding to not jump back and forth on pulses.
- Fixed tracking during slew. We now turn off tracking for slew and compensate at the end of the slew.
- Fixed type for DEC motor speed.
- Added M33 and Pleiades to GO menu.
- Added lots of debug output around stepper motor control under new macro DEBUG_STEPPERS