### PR TITLE
Removed mainLoopTask to avoid kernal panic due to re-entrancy on TWI …

### DIFF
--- a/Software/Arduino code/OpenAstroTracker/Configuration_pins.hpp
+++ b/Software/Arduino code/OpenAstroTracker/Configuration_pins.hpp
@@ -65,16 +65,16 @@
 #ifdef ESP32
 
   // RA Motor pins
-  #define RA_IN1_PIN  19  
-  #define RA_IN2_PIN  21  
-  #define RA_IN3_PIN  22  
-  #define RA_IN4_PIN  23  
+  #define RA_IN1_PIN  13
+  #define RA_IN2_PIN  14
+  #define RA_IN3_PIN  12
+  #define RA_IN4_PIN  27
 
   // DEC Motor pins
-  #define DEC_IN1_PIN  16  
-  #define DEC_IN2_PIN  17  
-  #define DEC_IN3_PIN  5   
-  #define DEC_IN4_PIN  18  
+  #define DEC_IN1_PIN 26
+  #define DEC_IN2_PIN 33
+  #define DEC_IN3_PIN 25
+  #define DEC_IN4_PIN 32
 
   // If using NEMA steppers
   #define RA_STEP_PIN 19  // STEP
@@ -109,7 +109,4 @@
         #error GPS module not currently configured/supported in ESP32
     #endif
 
-    #if USE_GYRO_LEVEL == 1
-        #error Digital Level not currently configured/supported in ESP32
-    #endif
 #endif

--- a/Software/Arduino code/OpenAstroTracker/Configuration_pins.hpp
+++ b/Software/Arduino code/OpenAstroTracker/Configuration_pins.hpp
@@ -65,16 +65,16 @@
 #ifdef ESP32
 
   // RA Motor pins
-  #define RA_IN1_PIN  13
-  #define RA_IN2_PIN  14
-  #define RA_IN3_PIN  12
-  #define RA_IN4_PIN  27
+  #define RA_IN1_PIN  19  
+  #define RA_IN2_PIN  21  
+  #define RA_IN3_PIN  22  
+  #define RA_IN4_PIN  23  
 
   // DEC Motor pins
-  #define DEC_IN1_PIN 26
-  #define DEC_IN2_PIN 33
-  #define DEC_IN3_PIN 25
-  #define DEC_IN4_PIN 32
+  #define DEC_IN1_PIN  16  
+  #define DEC_IN2_PIN  17  
+  #define DEC_IN3_PIN  5   
+  #define DEC_IN4_PIN  18  
 
   // If using NEMA steppers
   #define RA_STEP_PIN 19  // STEP

--- a/Software/Arduino code/OpenAstroTracker/Constants.hpp
+++ b/Software/Arduino code/OpenAstroTracker/Constants.hpp
@@ -16,11 +16,15 @@
  *                                          directly to an Arduino UNO / Mega boards and controlled over I2C.
  * DISPLAY_TYPE_LCD_KEYPAD_I2C_MCP23017:    RGB LCD Keypad shield based on the MCP23017 I/O Expander. It can be mounted 
  *                                          directly to an Arduino UNO / Mega boards and controlled over I2C.                                         
+ * DISPLAY_TYPE_LCD_JOY_I2C_SSD1306:        I2C 32x128 OLED display module with SSD1306 controller, plus mini joystick
+ *                                          Display: https://www.banggood.com/Geekcreit-0_91-Inch-128x32-IIC-I2C-Blue-OLED-LCD-Display-DIY-Module-SSD1306-Driver-IC-DC-3_3V-5V-p-1140506.html
+ *                                          Joystick: https://www.banggood.com/3pcs-JoyStick-Module-Shield-2_54mm-5-pin-Biaxial-Buttons-Rocker-for-PS2-Joystick-Game-Controller-Sensor-p-1586026.html
  **/
 #define DISPLAY_TYPE_NONE                       0
 #define DISPLAY_TYPE_LCD_KEYPAD                 1
 #define DISPLAY_TYPE_LCD_KEYPAD_I2C_MCP23008    2
 #define DISPLAY_TYPE_LCD_KEYPAD_I2C_MCP23017    3
+#define DISPLAY_TYPE_LCD_JOY_I2C_SSD1306        4
 
 
 // Supported stepper models

--- a/Software/Arduino code/OpenAstroTracker/platformio.ini
+++ b/Software/Arduino code/OpenAstroTracker/platformio.ini
@@ -18,6 +18,7 @@ lib_deps =
 	waspinator/AccelStepper @ ^1.61
 	arduino-libraries/LiquidCrystal @ ^1.0.7
 	lincomatic/LiquidTWI2@^1.2.7
+	olikraus/U8g2@^2.28.8
 
 [env]
 framework = arduino
@@ -34,6 +35,7 @@ lib_deps =
 [env:esp32]
 platform = espressif32
 board = esp32dev
+monitor_filters = esp32_exception_decoder
 lib_deps = 
 	${common.lib_deps}
 	WiFi

--- a/Software/Arduino code/OpenAstroTracker/src/EPROMStore.cpp
+++ b/Software/Arduino code/OpenAstroTracker/src/EPROMStore.cpp
@@ -4,7 +4,34 @@
 
 // The platform-independant EEPROM class
 
-#ifdef ESPBOARD
+#if USE_DUMMY_EEPROM == 1
+
+static uint8_t dummyEepromStorage[32];
+
+// Initialize the EEPROM object for ESP boards, settign aside 32 bytes for storage
+void EPROMStore::initialize()
+{
+  LOGV1(DEBUG_EEPROM, F("EEPROM[DUMMY]: Startup with 32 bytes"));
+  memset(dummyEepromStorage, sizeof(dummyEepromStorage), 1);
+}
+
+// Update the given location with the given value
+void EPROMStore::update(int location, uint8_t value)
+{
+  LOGV3(DEBUG_EEPROM, F("EEPROM[DUMMY]: Writing %x to %d"), value, location);
+  dummyEepromStorage[location] = value;
+}
+
+// Read the value at the given location
+uint8_t EPROMStore::read(int location)
+{
+  uint8_t value;
+  value = dummyEepromStorage[location];
+  LOGV3(DEBUG_EEPROM, F("EEPROM[DUMMY]: Read %x from %d"), value, location);
+  return value;
+}
+
+#elif defined(ESPBOARD)
 
 // Initialize the EEPROM object for ESP boards, settign aside 32 bytes for storage
 void EPROMStore::initialize()

--- a/Software/Arduino code/OpenAstroTracker/src/EPROMStore.cpp
+++ b/Software/Arduino code/OpenAstroTracker/src/EPROMStore.cpp
@@ -6,24 +6,24 @@
 
 #if USE_DUMMY_EEPROM == 1
 
-static uint8_t dummyEepromStorage[32];
+static uint8_t dummyEepromStorage[EPROMStore::STORE_SIZE];
 
-// Initialize the EEPROM object for ESP boards, settign aside 32 bytes for storage
+// Initialize the EEPROM object for ESP boards, setting aside storage
 void EPROMStore::initialize()
 {
-  LOGV1(DEBUG_EEPROM, F("EEPROM[DUMMY]: Startup with 32 bytes"));
-  memset(dummyEepromStorage, sizeof(dummyEepromStorage), 1);
+  LOGV2(DEBUG_EEPROM, F("EEPROM[DUMMY]: Startup with %d bytes"), EPROMStore::STORE_SIZE);
+  memset(dummyEepromStorage, 0, sizeof(dummyEepromStorage));
 }
 
 // Update the given location with the given value
-void EPROMStore::update(int location, uint8_t value)
+void EPROMStore::update(uint8_t location, uint8_t value)
 {
   LOGV3(DEBUG_EEPROM, F("EEPROM[DUMMY]: Writing %x to %d"), value, location);
   dummyEepromStorage[location] = value;
 }
 
 // Read the value at the given location
-uint8_t EPROMStore::read(int location)
+uint8_t EPROMStore::read(uint8_t location)
 {
   uint8_t value;
   value = dummyEepromStorage[location];
@@ -36,12 +36,12 @@ uint8_t EPROMStore::read(int location)
 // Initialize the EEPROM object for ESP boards, settign aside 32 bytes for storage
 void EPROMStore::initialize()
 {
-  LOGV1(DEBUG_EEPROM, F("EEPROM[ESP]: Startup with 32 bytes"));
-  EEPROM.begin(32);
+  LOGV2(DEBUG_EEPROM, F("EEPROM[ESP]: Startup with %d bytes"), EPROMStore::STORE_SIZE);
+  EEPROM.begin(EPROMStore::STORE_SIZE);
 }
 
 // Update the given location with the given value
-void EPROMStore::update(int location, uint8_t value)
+void EPROMStore::update(uint8_t location, uint8_t value)
 {
   LOGV3(DEBUG_EEPROM, F("EEPROM[ESP]: Writing %x to %d"), value, location);
   EEPROM.write(location, value);
@@ -50,7 +50,7 @@ void EPROMStore::update(int location, uint8_t value)
 }
 
 // Read the value at the given location
-uint8_t EPROMStore::read(int location)
+uint8_t EPROMStore::read(uint8_t location)
 {
   uint8_t value;
   value = EEPROM.read(location);
@@ -67,14 +67,14 @@ void EPROMStore::initialize()
 }
 
 // Update the given location with the given value
-void EPROMStore::update(int location, uint8_t value)
+void EPROMStore::update(uint8_t location, uint8_t value)
 {
   LOGV3(DEBUG_EEPROM, F("EEPROM[Uno/Mega]: Writing8 %x to %d"), value, location);
   EEPROM.write(location, value);
 }
 
 // Read the value at the given location
-uint8_t EPROMStore::read(int location)
+uint8_t EPROMStore::read(uint8_t location)
 {
   uint8_t value = EEPROM.read(location);
   LOGV3(DEBUG_EEPROM, F("EEPROM[Uno/Mega]: Read8 %x from %d"), value, location);
@@ -83,41 +83,73 @@ uint8_t EPROMStore::read(int location)
 
 #endif
 
-void EPROMStore::updateInt16(int loByteAddr, int hiByteAddr, int16_t value)
+// Update the given location with the given value
+void EPROMStore::updateUint8(EPROMStore::Key location, uint8_t value)
 {
-  LOGV5(DEBUG_EEPROM, F("EEPROM: Writing16 %x (%d) to %d, %d"), value, value, loByteAddr, hiByteAddr);
-  update(loByteAddr, value & 0x00FF);
-  update(hiByteAddr, (value >> 8) & 0x00FF);
+  LOGV4(DEBUG_EEPROM, F("EEPROM: Writing8 %x (%d) to %d"), value, value, location);
+  update(location, value);
 }
 
-int16_t EPROMStore::readInt16(int loByteAddr, int hiByteAddr)
+// Read the value at the given location
+uint8_t EPROMStore::readUint8(EPROMStore::Key location)
 {
-  uint8_t valLo = EPROMStore::read(loByteAddr);
-  uint8_t valHi = EPROMStore::read(hiByteAddr);
-  uint16_t uValue = (uint16_t)valLo + (uint16_t)valHi * 256;
-  int16_t value = static_cast<int16_t>(uValue);
-  LOGV5(DEBUG_EEPROM, F("EEPROM: Read16 %x (%d) from %d, %d"), value, value, loByteAddr, hiByteAddr);
+  uint8_t value;
+  value = read(location);
+  LOGV4(DEBUG_EEPROM, F("EEPROM: Read8 %x (%d) from %d"), value, value, location);
   return value;
 }
 
-void EPROMStore::updateInt32(int lowestByteAddr, int32_t value)
+void EPROMStore::updateInt16(EPROMStore::Key location, int16_t value)
 {
-  LOGV5(DEBUG_EEPROM, F("EEPROM: Writing32 %x (%l) to %d-%d"), value, value, lowestByteAddr, lowestByteAddr + 3);
-  update(lowestByteAddr, value & 0x00FF);
-  update(lowestByteAddr + 1, (value >> 8) & 0x00FF);
-  update(lowestByteAddr + 2, (value >> 16) & 0x00FF);
-  update(lowestByteAddr + 3, (value >> 24) & 0x00FF);
+  LOGV4(DEBUG_EEPROM, F("EEPROM: Writing16 %x (%d) to %d"), value, value, location);
+  update(location, value & 0x00FF);
+  update(location+1, (value >> 8) & 0x00FF);
 }
 
-int32_t EPROMStore::readInt32(int lowestByteAddr)
+int16_t EPROMStore::readInt16(EPROMStore::Key location)
 {
-  uint8_t val1 = EPROMStore::read(lowestByteAddr);
-  uint8_t val2 = EPROMStore::read(lowestByteAddr + 1);
-  uint8_t val3 = EPROMStore::read(lowestByteAddr + 2);
-  uint8_t val4 = EPROMStore::read(lowestByteAddr + 3);
+  uint8_t valLo = EPROMStore::read(location);
+  uint8_t valHi = EPROMStore::read(location+1);
+  uint16_t uValue = (uint16_t)valLo + (uint16_t)valHi * 256;
+  int16_t value = static_cast<int16_t>(uValue);
+  LOGV4(DEBUG_EEPROM, F("EEPROM: Read16 %x (%d) from %d"), value, value, location);
+  return value;
+}
+
+void EPROMStore::updateUint16(EPROMStore::Key location, uint16_t value)
+{
+  LOGV4(DEBUG_EEPROM, F("EEPROM: Writing16 %x (%d) to %d"), value, value, location);
+  update(location, value & 0x00FF);
+  update(location+1, (value >> 8) & 0x00FF);
+}
+
+uint16_t EPROMStore::readUint16(EPROMStore::Key location)
+{
+  uint8_t valLo = EPROMStore::read(location);
+  uint8_t valHi = EPROMStore::read(location+1);
+  uint16_t value = (uint16_t)valLo + (uint16_t)valHi * 256;
+  LOGV4(DEBUG_EEPROM, F("EEPROM: Read16 %x (%d) from %d"), value, value, location);
+  return value;
+}
+
+void EPROMStore::updateInt32(EPROMStore::Key location, int32_t value)
+{
+  LOGV4(DEBUG_EEPROM, F("EEPROM: Writing32 %x (%l) to %d"), value, value, location);
+  update(location, value & 0x00FF);
+  update(location + 1, (value >> 8) & 0x00FF);
+  update(location + 2, (value >> 16) & 0x00FF);
+  update(location + 3, (value >> 24) & 0x00FF);
+}
+
+int32_t EPROMStore::readInt32(EPROMStore::Key location)
+{
+  uint8_t val1 = EPROMStore::read(location);
+  uint8_t val2 = EPROMStore::read(location + 1);
+  uint8_t val3 = EPROMStore::read(location + 2);
+  uint8_t val4 = EPROMStore::read(location + 3);
   LOGV5(DEBUG_EEPROM, F("EEPROM: Read32 read these bytes: %x %x %x %x"), val1, val2, val3, val4);
   uint32_t uValue = (uint32_t)val1 + (uint32_t)val2 * 256 + (uint32_t)val3 * 256 * 256 + (uint32_t)val4 * 256 * 256 * 256;
   int32_t value = static_cast<int32_t>(uValue);
-  LOGV4(DEBUG_EEPROM, F("EEPROM: Read32 which is %l from %d-%d"), value, lowestByteAddr, lowestByteAddr + 3);
+  LOGV3(DEBUG_EEPROM, F("EEPROM: Read32 which is %l from %d"), value, location);
   return value;
 }

--- a/Software/Arduino code/OpenAstroTracker/src/EPROMStore.hpp
+++ b/Software/Arduino code/OpenAstroTracker/src/EPROMStore.hpp
@@ -9,15 +9,44 @@ class EPROMStore {
 
 public:
 
+  enum Key { 
+    SPEED_FACTOR_LOW=0, SPEED_FACTOR_HIGH=3,  // Split as two discontinuous Uint8
+    HA_HOUR=1, HA_MINUTE=2, // Both Uint8
+    FLAGS=4,  // Uint8
+    MAGIC_MARKER=5, // Uint8
+    MAGIC_MARKER_AND_FLAGS=4,   // Alias for Uint16 access
+    RA_STEPS_DEGREE=6, _RA_STEPS_DEGREE_1=7,    // Int16
+    DEC_STEPS_DEGREE=8, _DEC_STEPS_DEGREE_1=9,  // Int16
+    BACKLASH_STEPS=10, _BACKLASH_STEPS_1=11,    // Int16
+    LATITUDE=12, _LATITUDE_1=13,    // Int16
+    LONGITUDE=14, _LONGITUDE_1=13,  // Int16
+    LCD_BRIGHTNESS=16, // Uint8
+    PITCH_OFFSET=17, _PITCH_OFFSET_1=18,  // Uint16
+    ROLL_OFFSET=19, _ROLL_OFFSET_1=20,    // Uint16
+    EXTENDED_FLAGS=21, _EXTENDED_FLAGS_1=22,  // Uint16
+    RA_PARKING_POS=23, _RA_PARKING_POS_1, _RA_PARKING_POS_2, _RA_PARKING_POS_3,     // Int32
+    DEC_PARKING_POS=27, _DEC_PARKING_POS_1, _DEC_PARKING_POS_2, _DEC_PARKING_POS_3, // Int32
+    DEC_LOWER_LIMIT=31, _DEC_LOWER_LIMIT_1, _DEC_LOWER_LIMIT_2, _DEC_LOWER_LIMIT_3, // Int32
+    DEC_UPPER_LIMIT=35, _DEC_UPPER_LIMIT_1, _DEC_UPPER_LIMIT_2, _DEC_UPPER_LIMIT_3, // Int32
+    STORE_SIZE=64   
+  };
+
   static void initialize();
 
-  static void update(int location, uint8_t value);
-  static uint8_t read(int location);
+  static void updateUint8(Key location, uint8_t value);
+  static uint8_t readUint8(Key location);
 
-  static void updateInt16(int loByteAddr, int hiByteAddr, int16_t value);
-  static int16_t readInt16(int loByteAddr, int hiByteAddr);
+  static void updateUint16(Key location, uint16_t value);
+  static uint16_t readUint16(Key location);
 
-  static void updateInt32(int lowestByteAddr, int32_t value);
-  static int32_t readInt32(int lowestByteAddr);
+  static void updateInt16(Key location, int16_t value);
+  static int16_t readInt16(Key location);
+
+  static void updateInt32(Key location, int32_t value);
+  static int32_t readInt32(Key location);
+
+private:
+  static void update(uint8_t location, uint8_t value);
+  static uint8_t read(uint8_t location);
 };
 

--- a/Software/Arduino code/OpenAstroTracker/src/Gyro.cpp
+++ b/Software/Arduino code/OpenAstroTracker/src/Gyro.cpp
@@ -8,30 +8,34 @@
 
 const int MPU = 0x68; // I2C address of the MPU6050 accelerometer
 
-int16_t Gyro::AcX, Gyro::AcY, Gyro::AcZ;
-int16_t Gyro::AcXOffset, Gyro::AcYOffset, Gyro::AcZOffset;
+bool Gyro::isPresent(false);
 
 void Gyro::startup()
 {
     // Initialize interface to the MPU6050
     LOGV1(DEBUG_INFO, F("GYRO:: Starting"));
     Wire.begin();
+
     Wire.beginTransmission(MPU);
-    Wire.write(0x6B);
-    Wire.write(0);
+    Wire.write(0x75);   // WHO_AM_I
+    Wire.endTransmission(true);
+    Wire.requestFrom(MPU, 1, 1);
+    byte id = (Wire.read() >> 1) & 0x3F;    
+    isPresent = (id == 0x34);
+    if (!isPresent) {
+        LOGV1(DEBUG_INFO, F("GYRO:: Not found!"));
+        return;
+    }
+
+    Wire.beginTransmission(MPU);
+    Wire.write(0x6B);   // PWR_MGMT_1
+    Wire.write(0);      // Disable sleep, 8 MHz clock
+    Wire.endTransmission(true);
+    Wire.beginTransmission(MPU);
+    Wire.write(0x1A);   // CONFIG
+    Wire.write(6);      // 5Hz bandwidth
     Wire.endTransmission(true);
 
-    // read the values 100 times for them to stabilize
-    for (int i = 0; i < 100; i++)
-    {
-        Wire.beginTransmission(MPU);
-        Wire.write(0x3B); // Start with register 0x3B (ACCEL_XOUT_H)
-        Wire.endTransmission(false);
-        Wire.requestFrom(MPU, 6, 1);       // Read 6 registers total, each axis value is stored in 2 registers
-        AcX = Wire.read() << 8 | Wire.read(); // X-axis value
-        AcY = Wire.read() << 8 | Wire.read(); // Y-axis value
-        AcZ = Wire.read() << 8 | Wire.read(); // Z-axis value
-    }
     LOGV1(DEBUG_INFO, F("GYRO:: Started"));
 }
 
@@ -48,20 +52,25 @@ angle_t Gyro::getCurrentAngles()
     struct angle_t result;
     result.pitchAngle = 0;
     result.rollAngle = 0;
+    if (!isPresent)
+        return result;     // Gyro is not available
+
     for (int i = 0; i < windowSize; i++)
     {
         Wire.beginTransmission(MPU);
         Wire.write(0x3B); // Start with register 0x3B (ACCEL_XOUT_H)
         Wire.endTransmission(false);
         Wire.requestFrom(MPU, 6, 1);       // Read 6 registers total, each axis value is stored in 2 registers
-        AcX = Wire.read() << 8 | Wire.read(); // X-axis value
-        AcY = Wire.read() << 8 | Wire.read(); // Y-axis value
-        AcZ = Wire.read() << 8 | Wire.read(); // Z-axis value
+        int16_t AcX = Wire.read() << 8 | Wire.read(); // X-axis value
+        int16_t AcY = Wire.read() << 8 | Wire.read(); // Y-axis value
+        int16_t AcZ = Wire.read() << 8 | Wire.read(); // Z-axis value
 
         // Calculating the Pitch angle (rotation around Y-axis)
         result.pitchAngle += ((atan(-1 * AcX / sqrt(pow(AcY, 2) + pow(AcZ, 2))) * 180.0 / PI) * 2.0) / 2.0;
         // Calculating the Roll angle (rotation around X-axis)
         result.rollAngle += ((atan(-1 * AcY / sqrt(pow(AcX, 2) + pow(AcZ, 2))) * 180.0 / PI) * 2.0) / 2.0;
+
+        delay(10);  // Decorrelate measurements
     }
 
     result.pitchAngle /= windowSize;
@@ -76,6 +85,9 @@ angle_t Gyro::getCurrentAngles()
 
 float Gyro::getCurrentTemperature()
 {
+    if (!isPresent)
+        return 99.9;     // Gyro is not available
+
     // Read the temperature data
     float result = 0.0;
     int16_t tempValue;

--- a/Software/Arduino code/OpenAstroTracker/src/Gyro.cpp
+++ b/Software/Arduino code/OpenAstroTracker/src/Gyro.cpp
@@ -27,7 +27,7 @@ void Gyro::startup()
         Wire.beginTransmission(MPU);
         Wire.write(0x3B); // Start with register 0x3B (ACCEL_XOUT_H)
         Wire.endTransmission(false);
-        Wire.requestFrom(MPU, 6, true);       // Read 6 registers total, each axis value is stored in 2 registers
+        Wire.requestFrom(MPU, 6, 1);       // Read 6 registers total, each axis value is stored in 2 registers
         AcX = Wire.read() << 8 | Wire.read(); // X-axis value
         AcY = Wire.read() << 8 | Wire.read(); // Y-axis value
         AcZ = Wire.read() << 8 | Wire.read(); // Z-axis value
@@ -38,7 +38,7 @@ void Gyro::startup()
 void Gyro::shutdown()
 {
     LOGV1(DEBUG_INFO, F("GYRO: Shutdown"));
-    Wire.end();
+    // Nothing to do
 }
 
 angle_t Gyro::getCurrentAngles()
@@ -53,7 +53,7 @@ angle_t Gyro::getCurrentAngles()
         Wire.beginTransmission(MPU);
         Wire.write(0x3B); // Start with register 0x3B (ACCEL_XOUT_H)
         Wire.endTransmission(false);
-        Wire.requestFrom(MPU, 6, true);       // Read 6 registers total, each axis value is stored in 2 registers
+        Wire.requestFrom(MPU, 6, 1);       // Read 6 registers total, each axis value is stored in 2 registers
         AcX = Wire.read() << 8 | Wire.read(); // X-axis value
         AcY = Wire.read() << 8 | Wire.read(); // Y-axis value
         AcZ = Wire.read() << 8 | Wire.read(); // Z-axis value
@@ -82,7 +82,7 @@ float Gyro::getCurrentTemperature()
     Wire.beginTransmission(MPU);
     Wire.write(0x41); // Start with register 0x41 (TEMP_OUT_H)
     Wire.endTransmission(false);
-    Wire.requestFrom(MPU, 2, true);             // Read 2 registers total, the temperature value is stored in 2 registers
+    Wire.requestFrom(MPU, 2, 1);             // Read 2 registers total, the temperature value is stored in 2 registers
     tempValue = Wire.read() << 8 | Wire.read(); // Raw Temperature value
     // Calculating the actual temperature value
     result = float(tempValue) / 340 + 36.53;

--- a/Software/Arduino code/OpenAstroTracker/src/Gyro.hpp
+++ b/Software/Arduino code/OpenAstroTracker/src/Gyro.hpp
@@ -3,7 +3,7 @@
 #include "../Configuration_adv.hpp"
 
 #if USE_GYRO_LEVEL == 1
-struct angle_t { float pitchAngle; float rollAngle; };
+struct angle_t { float pitchAngle = 0; float rollAngle = 0; };
 
 class Gyro 
 {
@@ -14,7 +14,6 @@ public:
   static float getCurrentTemperature();
   
 private:
-  static int16_t AcX, AcY, AcZ;
-  static int16_t AcXOffset, AcYOffset, AcZOffset;
+  static bool isPresent;  // True if gyro correctly detected on startup
 };
 #endif

--- a/Software/Arduino code/OpenAstroTracker/src/LcdMenu.cpp
+++ b/Software/Arduino code/OpenAstroTracker/src/LcdMenu.cpp
@@ -60,7 +60,7 @@ void LcdMenu::startup()
   _lcd.setBacklight(RED);
   #endif
 
-  _brightness = EPROMStore::read(16);
+  _brightness = EPROMStore::readUint8(EPROMStore::LCD_BRIGHTNESS);
   LOGV2(DEBUG_INFO, F("LCD: Brightness from EEPROM is %d"), _brightness);
   // pinMode(10, OUTPUT);
   // analogWrite(10, _brightness);
@@ -142,7 +142,7 @@ void LcdMenu::setBacklightBrightness(int level, bool persist)
   if (persist)
   {
     // LOGV2(DEBUG_INFO, F("LCD: Saving %d as brightness"), (_brightness & 0x00FF));
-    EPROMStore::update(EPROMStore::LCD_BRIGHTNESS, (byte)(_brightness & 0x00FF));
+    EPROMStore::updateUint8(EPROMStore::LCD_BRIGHTNESS, (byte)(_brightness & 0x00FF));
   }
 }
 

--- a/Software/Arduino code/OpenAstroTracker/src/LcdMenu.hpp
+++ b/Software/Arduino code/OpenAstroTracker/src/LcdMenu.hpp
@@ -7,6 +7,8 @@
 #include <LiquidCrystal.h>
 #elif DISPLAY_TYPE == DISPLAY_TYPE_LCD_KEYPAD_I2C_MCP23008 || DISPLAY_TYPE == DISPLAY_TYPE_LCD_KEYPAD_I2C_MCP23017
 #include <LiquidTWI2.h>
+#elif DISPLAY_TYPE == DISPLAY_TYPE_LCD_JOY_I2C_SSD1306
+#include <U8x8lib.h>        // https://github.com/olikraus/u8g2
 #endif
 
 // A single menu item (like RA, HEAT, POL, etc.)
@@ -87,16 +89,19 @@ private:
 private:
 #if DISPLAY_TYPE > 0
 
-  byte _cols;
-  byte _rows;
-  byte _maxItems;
-
   #if DISPLAY_TYPE == DISPLAY_TYPE_LCD_KEYPAD
     LiquidCrystal _lcd;   // The LCD screen that we'll display the menu on
   #elif DISPLAY_TYPE == DISPLAY_TYPE_LCD_KEYPAD_I2C_MCP23008 || DISPLAY_TYPE == DISPLAY_TYPE_LCD_KEYPAD_I2C_MCP23017
     LiquidTWI2 _lcd;   // The LCD screen that we'll display the menu on
+  #elif DISPLAY_TYPE == DISPLAY_TYPE_LCD_JOY_I2C_SSD1306
+    U8X8_SSD1306_128X32_UNIVISION_HW_I2C _lcd;  
   #endif
-  
+
+  byte const _cols;
+  byte const _rows;
+  byte const _maxItems;
+  byte const _charHeightRows;   // Height of character in display native rows
+
   MenuItem** _menuItems;  // The first menu item (linked list)
   byte _numMenuItems;
   byte _activeMenuIndex;
@@ -107,6 +112,7 @@ private:
   String _lastDisplay[2]; // The last string that was displayed on each row
   int _brightness;
 
+#if DISPLAY_TYPE != DISPLAY_TYPE_LCD_JOY_I2C_SSD1306
   byte _degrees = 1;
   byte _minutes = 2;
   byte _leftArrow = 3;
@@ -115,7 +121,6 @@ private:
   byte _downArrow = 6;
   byte _tracking = 7;
   byte _noTracking = 0;
-
 
   // The special character bitmaps
   static byte RightArrowBitmap[8];
@@ -126,6 +131,7 @@ private:
   static byte MinutesBitmap[8];
   static byte TrackingBitmap[8];
   static byte NoTrackingBitmap[8];
+#endif
 
 #endif
 };

--- a/Software/Arduino code/OpenAstroTracker/src/Mount.cpp
+++ b/Software/Arduino code/OpenAstroTracker/src/Mount.cpp
@@ -1,5 +1,3 @@
-#include "InterruptCallback.hpp"
-
 #include "LcdMenu.hpp"
 #include "Mount.hpp"
 #include "Utility.hpp"
@@ -98,15 +96,6 @@ const char* formatStringsRA[] = {
   "%02d%02d%02d",           // Compact
 };
 
-/////////////////////////////////
-// This is the callback function for the timer interrupt. It does very minimal work,
-// only stepping the stepper motors as needed.
-/////////////////////////////////
-void mountLoop(void* payload) {
-  Mount* mount = reinterpret_cast<Mount*>(payload);
-  mount->interruptLoop();
-}
-
 Mount* Mount::_instance = nullptr;
 Mount Mount::instance() { return *_instance; };
 
@@ -163,23 +152,6 @@ Mount::Mount(int stepsPerRADegree, int stepsPerDECDegree, LcdMenu* lcdMenu) {
   _pitchCalibrationAngle = 0;
   _rollCalibrationAngle = 0;
   #endif
-}
-
-/////////////////////////////////
-//
-// startTimerInterrupts
-//
-/////////////////////////////////
-void Mount::startTimerInterrupts()
-{
-#ifndef ESPBOARD
-  // 2 kHz updates (higher frequency interferes with serial communications and complete messes up OATControl communications)
-  if (!InterruptCallback::setInterval(0.5f, mountLoop, this))
-  {
-    LOGV1(DEBUG_MOUNT, F("Mount:: CANNOT setup interrupt timer!"));
-  }
-#endif // !ESPBOARD
-
 }
 
 /////////////////////////////////

--- a/Software/Arduino code/OpenAstroTracker/src/Mount.hpp
+++ b/Software/Arduino code/OpenAstroTracker/src/Mount.hpp
@@ -267,9 +267,6 @@ public:
   // Get the number of steps to use for backlash correction
   int getBacklashCorrection();
   
-  // Called when startup is complete and the mount needs to start updating steppers.
-  void startTimerInterrupts();
-
   // Read the saved configuration from persistent storage
   void readConfiguration();
 

--- a/Software/Arduino code/OpenAstroTracker/src/Mount.hpp
+++ b/Software/Arduino code/OpenAstroTracker/src/Mount.hpp
@@ -1,10 +1,6 @@
 #ifndef _MOUNT_HPP_
 #define _MOUNT_HPP_
 
-#if DISPLAY_TYPE > 0
-#include <LiquidCrystal.h>
-#endif
-
 #include <AccelStepper.h>
 #include "inc/Config.hpp"
 #include "DayTime.hpp"
@@ -32,9 +28,9 @@
 #define TARGET_STRING      B01000
 #define CURRENT_STRING     B10000
 
-#define HALFSTEP_MODE 8
-#define FULLSTEP_MODE 4
-#define DRIVER_MODE 1
+#define HALFSTEP_MODE AccelStepper::HALF4WIRE
+#define FULLSTEP_MODE AccelStepper::FULL4WIRE
+#define DRIVER_MODE AccelStepper::DRIVER
 
 #define RA_STEPS  1
 #define DEC_STEPS 2

--- a/Software/Arduino code/OpenAstroTracker/src/a_inits.hpp
+++ b/Software/Arduino code/OpenAstroTracker/src/a_inits.hpp
@@ -1,9 +1,6 @@
 #pragma once
 
 #include <AccelStepper.h>
-#if DISPLAY_TYPE > 0
-#include <LiquidCrystal.h>
-#endif
 #include "inc/Globals.hpp"
 
 #include "Utility.hpp"
@@ -22,10 +19,6 @@
   //SoftwareSerial SoftSerial(GPS_SERIAL_RX_PIN, GPS_SERIAL_TX_PIN); // RX, TX
   TinyGPSPlus gps;
 #endif
-
-#define HALFSTEP_MODE 8
-#define FULLSTEP_MODE 4
-#define DRIVER_MODE 1
 
 ////////////////////////////////////
 // Stepper definitions /////////////

--- a/Software/Arduino code/OpenAstroTracker/src/b_setup.hpp
+++ b/Software/Arduino code/OpenAstroTracker/src/b_setup.hpp
@@ -145,17 +145,17 @@ void setup() {
   // Calling the LCD startup here, I2C can't be found if called earlier
   #if DISPLAY_TYPE > 0
     lcdMenu.startup();
-  #endif
+#endif
 
-  LOGV1(DEBUG_ANY, F("Finishing boot..."));
-  // Show a splash screen
-  lcdMenu.setCursor(0, 0);
-  lcdMenu.printMenu("OpenAstroTracker");
-  lcdMenu.setCursor(5, 1);
-  lcdMenu.printMenu(VERSION);
+    LOGV1(DEBUG_ANY, F("Finishing boot..."));
+    // Show a splash screen
+    lcdMenu.setCursor(0, 0);
+    lcdMenu.printMenu("OpenAstroTracker");
+    lcdMenu.setCursor(5, 1);
+    lcdMenu.printMenu(VERSION);
 
-  #if DISPLAY_TYPE > 0
-    // Check for EEPROM reset (Button down during boot)
+#if DISPLAY_TYPE > 0
+      // Check for EEPROM reset (Button down during boot)
     if (lcdButtons.currentState() == btnDOWN){
       LOGV1(DEBUG_INFO, F("Erasing configuration in EEPROM!"));
       mount.clearConfiguration();
@@ -167,7 +167,7 @@ void setup() {
       }
     }
 
-  unsigned long now = millis();
+    unsigned long now = millis();
   #endif
   
   LOGV2(DEBUG_ANY, F("Hardware: %s"), mount.getMountHardwareInfo().c_str());
@@ -227,7 +227,7 @@ void setup() {
   mount.readConfiguration();
   
   // Read other persisted values and set in mount
-  DayTime haTime = DayTime(EPROMStore::read(1), EPROMStore::read(2), 0);
+  DayTime haTime = DayTime(EPROMStore::readUint8(EPROMStore::HA_HOUR), EPROMStore::readUint8(EPROMStore::HA_MINUTE), 0);
 
   LOGV2(DEBUG_INFO, "SpeedCal: %s", String(mount.getSpeedCalibration(), 5).c_str());
   LOGV2(DEBUG_INFO, "TRKSpeed: %s", String(mount.getSpeed(TRACKING), 5).c_str());
@@ -244,7 +244,7 @@ void setup() {
   LOGV1(DEBUG_ANY, F("Start Tracking..."));
   mount.startSlewing(TRACKING);
 
-  #if DISPLAY_TYPE > 0
+#if DISPLAY_TYPE > 0
     LOGV1(DEBUG_ANY, F("Setup menu system..."));
 
     // Create the LCD top-level menu items

--- a/Software/Arduino code/OpenAstroTracker/src/c72_menuHA.hpp
+++ b/Software/Arduino code/OpenAstroTracker/src/c72_menuHA.hpp
@@ -35,8 +35,8 @@ bool processHAKeys() {
       break;
 
       case btnSELECT: {
-        EPROMStore::update(1, mount.HA().getHours());
-        EPROMStore::update(2, mount.HA().getMinutes());
+        EPROMStore::updateUint8(EPROMStore::HA_HOUR, mount.HA().getHours());
+        EPROMStore::updateUint8(EPROMStore::HA_MINUTE, mount.HA().getMinutes());
         lcdMenu.printMenu("Stored.");
         mount.delay(500);
 


### PR DESCRIPTION
…from multiple loop(). loop() now runs on Core1 (Arduino default) and steppers run on Core 0. This fix allows I2C displays to work on ESP32. It will also allow Gyro to work on ESP32 but need to fix some minor compilation issues first. Removed separate finishSetup() - setup() just continues on.
Some minor updates to logging as well.